### PR TITLE
Omega v rho

### DIFF
--- a/single_ef_coh_ddebiff_continuation.m
+++ b/single_ef_coh_ddebiff_continuation.m
@@ -38,7 +38,7 @@ figure(2); clf;
 [branch1,s,f,r]=br_contn(funcs,branch1,200);
 title(strcat('Omega-vs-', plot_param_name))
 xlabel(strcat(plot_param_name,{' '}, plot_param_unit))
-ylabel('Omega (?? units)')
+ylabel('Omega (1/\tau_{sp})')
 
 
 % --
@@ -51,7 +51,7 @@ branch1.method.stability.minimal_real_part = -1.0
 [nunst_branch1,dom,defect,branch1.point]=GetStability(branch1,...
 'exclude_trivial',true,'locate_trivial',@(p)0,'funcs',funcs);
 
-figure(3); clf;
+figure(4); clf;
 stst_contin_param_vals = arrayfun(@(p)p.parameter(par_cont_ind(1)),branch1.point); %Get stst continued parameter values
 stst_contin_ef_vals = arrayfun(@(p)norm(p.x(1:2)),branch1.point); %Get stst normed ef vals
 sel=@(x,i)x(nunst_branch1==i);
@@ -67,8 +67,23 @@ title({strcat('Electric Field Amplitude-vs-', plot_param_name); strcat('with J='
 xlabel(strcat(plot_param_name,{' '}, plot_param_unit))
 ylabel(strcat({'|E(t)| '}, ef_units))
 
+%remake '.method.continuation.plot' omega vs continuation param plot
+%stst_contin_param_vals already set above
+stst_contin_omega_vals = arrayfun(@(p)p.parameter(ind_omega),branch1.point);
+plot(sel(stst_contin_param_vals,0),sel(stst_contin_omega_vals,0),'k.', ...
+    sel(stst_contin_param_vals,1),sel(stst_contin_omega_vals,1),'r.',...
+    sel(stst_contin_param_vals,2),sel(stst_contin_omega_vals,2),'c.',...
+    sel(stst_contin_param_vals,3),sel(stst_contin_omega_vals,3),'b.',...
+    sel(stst_contin_param_vals,4),sel(stst_contin_omega_vals,4),'g.',...
+    sel(stst_contin_param_vals,5),sel(stst_contin_omega_vals,5),'m.',...
+    sel(stst_contin_param_vals,6),sel(stst_contin_omega_vals,6),'y.',...
+    'linewidth',2);
+title(strcat('Omega-vs-', plot_param_name))
+xlabel(strcat(plot_param_name,{' '}, plot_param_unit))
+ylabel('Omega (1/\tau_{sp})')
+
 %from lina's example, plot real eigenvalue part versus parameter
-figure(4); clf;
+figure(5); clf;
 [x_measure,y_measure]= df_measr(1,branch1);
 br_plot(branch1,x_measure,y_measure);
 title(strcat('Real part of Eigenvalues-vs-', plot_param_name))

--- a/single_ef_coh_ddebiff_continuation.m
+++ b/single_ef_coh_ddebiff_continuation.m
@@ -51,7 +51,7 @@ branch1.method.stability.minimal_real_part = -1.0
 [nunst_branch1,dom,defect,branch1.point]=GetStability(branch1,...
 'exclude_trivial',true,'locate_trivial',@(p)0,'funcs',funcs);
 
-figure(4); clf;
+figure(3); clf;
 stst_contin_param_vals = arrayfun(@(p)p.parameter(par_cont_ind(1)),branch1.point); %Get stst continued parameter values
 stst_contin_ef_vals = arrayfun(@(p)norm(p.x(1:2)),branch1.point); %Get stst normed ef vals
 sel=@(x,i)x(nunst_branch1==i);
@@ -68,7 +68,8 @@ xlabel(strcat(plot_param_name,{' '}, plot_param_unit))
 ylabel(strcat({'|E(t)| '}, ef_units))
 
 %remake '.method.continuation.plot' omega vs continuation param plot
-%stst_contin_param_vals already set above
+figure(2);clf;
+%stst_contin_param_vals is already set above
 stst_contin_omega_vals = arrayfun(@(p)p.parameter(ind_omega),branch1.point);
 plot(sel(stst_contin_param_vals,0),sel(stst_contin_omega_vals,0),'k.', ...
     sel(stst_contin_param_vals,1),sel(stst_contin_omega_vals,1),'r.',...
@@ -80,6 +81,22 @@ plot(sel(stst_contin_param_vals,0),sel(stst_contin_omega_vals,0),'k.', ...
     'linewidth',2);
 title(strcat('Omega-vs-', plot_param_name))
 xlabel(strcat(plot_param_name,{' '}, plot_param_unit))
+ylabel('Omega (1/\tau_{sp})')
+
+%Omega vs QD Occupation Probability (\rho) with stability
+figure(4); clf;
+stst_contin_rho_vals = arrayfun(@(p)p.x(3),branch1.point);
+stst_contin_omega_vals = arrayfun(@(p)p.parameter(ind_omega),branch1.point);
+plot(sel(stst_contin_rho_vals,0),sel(stst_contin_omega_vals,0),'k.', ...
+    sel(stst_contin_rho_vals,1),sel(stst_contin_omega_vals,1),'r.',...
+    sel(stst_contin_rho_vals,2),sel(stst_contin_omega_vals,2),'c.',...
+    sel(stst_contin_rho_vals,3),sel(stst_contin_omega_vals,3),'b.',...
+    sel(stst_contin_rho_vals,4),sel(stst_contin_omega_vals,4),'g.',...
+    sel(stst_contin_rho_vals,5),sel(stst_contin_omega_vals,5),'m.',...
+    sel(stst_contin_rho_vals,6),sel(stst_contin_omega_vals,6),'y.',...
+    'linewidth',2);
+title('Omega vs QD Occupation Probability (\rho)')
+xlabel('\rho (no units)')
 ylabel('Omega (1/\tau_{sp})')
 
 %from lina's example, plot real eigenvalue part versus parameter
@@ -142,20 +159,74 @@ if continue_choice == 1
 
   % Hardcoded for the axes to remain the same. I don't think there is a good way to get around this.
   h1branch.method.continuation.plot=1;
-  figure(5); clf;
+  figure(6); clf;
   [h1branch,suc]=SetupRWHopf(funcs,branch1,ind_hopf(1),...
     'contpar',[ind_feed_phase, ind_feed_ampli, ind_omega],opt_inputs{:},...
     'print_residual_info',1,'dir',ind_feed_ampli,'step',0.01,'minimal_accuracy',1e-4,...
     'max_bound',[ind_feed_ampli,0.99]);
   h1branch=br_contn(funcs,h1branch,100);
   h1branch=br_rvers(h1branch);
-  h1branch=br_contn(funcs,h1branch,100)
+  h1branch=br_contn(funcs,h1branch,100);
   title(strcat('Feedback Ampli vs Feedback Phase - Hopf Bifurcation Continuation'))
   xlabel('Feedback Phase (no units)')
   ylabel('Feedback Ampli (no units)')
+  %prepare points for combined plot
+  h1branch_feed_phase_vals = arrayfun(@(p)p.parameter(ind_feed_phase),h1branch.point);
+  h1branch_feed_ampli_vals = arrayfun(@(p)p.parameter(ind_feed_ampli),h1branch.point);
+  
+  %Augment omega vs 'plot_param_name' with boxes around potential hopf bifurcations
+  figure(2);
+  hold on
+  plot(stst_contin_param_vals(ind_hopf),stst_contin_omega_vals(ind_hopf),'ks','linewidth',2);
+  hold off
+  
+  % Hardcoded for the axes to remain the same. I don't think there is a good way to get around this.
+  % This one starts at the hopf bifurcation symetric to the one above.
+  h2branch.method.continuation.plot=1;
+  figure(6);
+  [h2branch,suc]=SetupRWHopf(funcs,branch1,ind_hopf(12),...
+    'contpar',[ind_feed_phase, ind_feed_ampli, ind_omega],opt_inputs{:},...
+    'print_residual_info',1,'dir',ind_feed_ampli,'step',0.01,'minimal_accuracy',1e-4,...
+    'max_bound',[ind_feed_ampli,1.2]);
+  h2branch=br_contn(funcs,h2branch,100);
+  h2branch=br_rvers(h2branch);
+  h2branch=br_contn(funcs,h2branch,100);
+  title(strcat('Feedback Ampli vs Feedback Phase - Hopf Bifurcation Continuation'))
+  xlabel('Feedback Phase (no units)')
+  ylabel('Feedback Ampli (no units)')
+  %prepare points for combined plot
+  h2branch_feed_phase_vals = arrayfun(@(p)p.parameter(ind_feed_phase),h2branch.point);
+  h2branch_feed_ampli_vals = arrayfun(@(p)p.parameter(ind_feed_ampli),h2branch.point);
   
   
+  %%
+  %% Now let's look at the fold bifurcation
   
+  ind_fold=find(abs(diff(nunst_branch1))==1);
+  [foldfuncs,fold1branch,suc]=SetupRWFold(funcs,branch1,ind_fold(1),...
+      'contpar',[ind_feed_phase, ind_feed_ampli, ind_omega],opt_inputs{:},...
+      'print_residual_info',1,'dir',ind_feed_ampli,'step',0.01,...
+      'max_bound',[ind_feed_ampli,1.2]); %'max_step',[ind_phi,0.1; ind_eta,0.01]);
+  figure(6);
+  fold1branch=br_contn(foldfuncs,fold1branch,60);
+  fold1branch=br_rvers(fold1branch);
+  fold1branch=br_contn(foldfuncs,fold1branch,60);
+  title(strcat('Feedback Ampli vs Feedback Phase - Fold/Saddle-Node Bifurcation Continuation'))
+  xlabel('Feedback Phase (no units)')
+  ylabel('Feedback Ampli (no units)')
+  %prepare points for combined plot
+  fold1branch_feed_phase_vals = arrayfun(@(p)p.parameter(ind_feed_phase),fold1branch.point);
+  fold1branch_feed_ampli_vals = arrayfun(@(p)p.parameter(ind_feed_ampli),fold1branch.point);
+  
+  % Plot all of these color coded bifurcations on the same graph
+  figure(6); clf;
+  plot(h1branch_feed_phase_vals, h1branch_feed_ampli_vals, 'k.', ...
+      h2branch_feed_phase_vals, h2branch_feed_ampli_vals, 'r.', ...
+      fold1branch_feed_phase_vals, fold1branch_feed_ampli_vals, 'b.', ...
+      'linewidth',2);
+  title(strcat('Feedback Ampli vs Feedback Phase - Combined Bifurcation Continuation'))
+  xlabel('Feedback Phase (no units)')
+  ylabel('Feedback Ampli (no units)')
       
 elseif continue_choice == 2
   %DEFINE FEED AMPLI


### PR DESCRIPTION
Add omega versus rho, which does not depend on a +/- 2pi shift, to clarify low tau_fp option.

Add another hopf continuation symmetric to the other one, also a fold/saddle-node continuation, which shows how the bifurcations are connected.